### PR TITLE
Added TODO to change image push branch

### DIFF
--- a/.github/workflows/image_build_push.yml
+++ b/.github/workflows/image_build_push.yml
@@ -6,6 +6,10 @@ name: docker-image-push-join
 # events but only for the master branch
 on:
   push:
+    # Mukul:
+    # I've added a local test branch on my system and using it for testing image push.
+    # So, for testing purposes, need to checkout a branch "image-push-merge"
+    # TODO: Need to change to build off master or main once it looks good.
     branches: [ image-push-merge ]
 
 


### PR DESCRIPTION
Currently the branch specified - "image-push-merge" is available locally on my system. 
I use it to test the automated docker image push mechanism whenever any changes are merged to this branch. 
Once, everything looks good, need to change this to master or main as per the repo.